### PR TITLE
Null instance error

### DIFF
--- a/src/pawn.gd
+++ b/src/pawn.gd
@@ -93,7 +93,10 @@ func follow_the_path(delta):
 
 
 func adjust_to_center():
-	move_direction = get_tile().global_transform.origin-global_transform.origin
+	if get_tile():
+		move_direction = get_tile().global_transform.origin-global_transform.origin
+	else:
+		move_direction = Vector3.ZERO
 	set_velocity(move_direction*SPEED*4)
 	set_up_direction(Vector3.UP)
 	move_and_slide()


### PR DESCRIPTION
```
get_tile():
	return $Tile.get_collider()
```

`.get_collider()` returns "null" if no object is intersecting the ray
This triggered a null instance error for me
![image](https://github.com/ramaureirac/godot-tactical-rpg/assets/17831738/b26c8c40-bc04-4cf8-bb18-43022f6ca9fa)

Maybe I missed something, please let me know if I did :)
Since your test_level is not throwing an error, it's highly likely I did